### PR TITLE
Follow redirects in downloadFile

### DIFF
--- a/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
+++ b/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.benson.pinch.test;
+package guru.benson.pinch.test;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
The method `Pinch.downloadFile(ExtendedZipEntry String, String, ProgressListener)` now follow redirects.

I also fixed the package name for the tests and added a test for downloading for a redirected url.