### PR TITLE
Use local file header to determinate where the file data is.

### DIFF
--- a/Pinch/src/guru/benson/pinch/ExtendedZipEntry.java
+++ b/Pinch/src/guru/benson/pinch/ExtendedZipEntry.java
@@ -25,7 +25,7 @@ public class ExtendedZipEntry extends ZipEntry {
 
     private short mInternalAttr;
     private short mExternalAttr;
-    private long mOffset;
+    private long  mOffset;
     private short mExtraLength;
 
     public ExtendedZipEntry(String name) {

--- a/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
+++ b/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
@@ -17,7 +17,6 @@
 package guru.benson.pinch.test;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
@@ -28,22 +27,24 @@ import guru.benson.pinch.ExtendedZipEntry;
 import guru.benson.pinch.Pinch;
 
 public class PinchTest extends InstrumentationTestCase {
-
-    final String testUrl = "http://www.cbconsulting.se/files/BSHInform.10.1.1-1.mib";
+    final String DOWNLOAD_DIR = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        + File.separator + "PinchTest";
 
     public void testFetchDirectory() throws Throwable {
-        URL url = new URL(testUrl);
+        URL url = new URL("http://www.cbconsulting.se/files/BSHInform.10.1.1-1.mib");
         Pinch p = new Pinch(url);
         List<ExtendedZipEntry> list = p.parseCentralDirectory();
         for (ExtendedZipEntry entry : list) {
-            try {
-                p.downloadFile(entry, Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                    + File.separator
-                    + entry.getName());
-            } catch (IOException e) {
-                e.printStackTrace();
-                break;
-            }
+            p.downloadFile(entry, DOWNLOAD_DIR + File.separator + "testFetchDirectory");
+        }
+    }
+
+    public void testFetchZipWithCentralAndLocalExtraMismatch() throws Throwable {
+        URL url = new URL("http://niiranen.net/assets/demo_1280_800_149.zip");
+        Pinch pinch = new Pinch(url);
+        List<ExtendedZipEntry> contents = pinch.parseCentralDirectory();
+        for (ExtendedZipEntry entry : contents) {
+            pinch.downloadFile(entry, DOWNLOAD_DIR + File.separator + "testFetchZipWithInvalidCentralData");
         }
     }
 }

--- a/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
+++ b/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
@@ -14,39 +14,36 @@
  * limitations under the License.
  */
 
-package com.benson.pinch.test;
+package guru.benson.pinch.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
 import android.os.Environment;
 import android.test.InstrumentationTestCase;
 
-import com.benson.pinch.ExtendedZipEntry;
-import com.benson.pinch.Pinch;
+import guru.benson.pinch.ExtendedZipEntry;
+import guru.benson.pinch.Pinch;
 
 public class PinchTest extends InstrumentationTestCase {
 
     final String testUrl = "http://www.cbconsulting.se/files/BSHInform.10.1.1-1.mib";
 
-    public void testFetchDirectory()  {
-        try {
-            URL url = new URL(testUrl);
-            Pinch p = new Pinch(url);
-            List<ExtendedZipEntry> list = p.parseCentralDirectory();
-            for (ExtendedZipEntry entry : list) {
-                try {
-                    p.downloadFile(entry, Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                            + File.separator
-                            + entry.getName());
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    break;
-                }
+    public void testFetchDirectory() throws Throwable {
+        URL url = new URL(testUrl);
+        Pinch p = new Pinch(url);
+        List<ExtendedZipEntry> list = p.parseCentralDirectory();
+        for (ExtendedZipEntry entry : list) {
+            try {
+                p.downloadFile(entry, Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                    + File.separator
+                    + entry.getName());
+            } catch (IOException e) {
+                e.printStackTrace();
+                break;
             }
-        } catch (MalformedURLException e) {}
+        }
     }
 }


### PR DESCRIPTION
As the extra field in the central header and local header can be different we cannot use the central header to determinate the file data offset.