### PR TITLE
Fix local header download

### DIFF
--- a/Pinch/src/guru/benson/pinch/Pinch.java
+++ b/Pinch/src/guru/benson/pinch/Pinch.java
@@ -492,11 +492,11 @@ public class Pinch {
         while ((read = is.read(dataBuffer)) != -1) {
             bytes += read;
         }
+        close(is);
+        disconnect(conn);
         if (bytes < ZipConstants.LOCHDR) {
             throw new IOException("Unable to fetch the local header");
         }
-        close(is);
-        disconnect(conn);
 
         ByteBuffer buffer = ByteBuffer.allocate(ZipConstants.LOCHDR);
         buffer.order(ByteOrder.LITTLE_ENDIAN);

--- a/Pinch/src/guru/benson/pinch/Pinch.java
+++ b/Pinch/src/guru/benson/pinch/Pinch.java
@@ -486,11 +486,13 @@ public class Pinch {
         }
 
         byte[] dataBuffer = new byte[2048];
-        int read;
+        int read, bytes = 0;
 
         is = conn.getInputStream();
-        read = is.read(dataBuffer, 0, ZipConstants.LOCHDR);
-        if (read < ZipConstants.LOCHDR) {
+        while ((read = is.read(dataBuffer)) != -1) {
+            bytes += read;
+        }
+        if (bytes < ZipConstants.LOCHDR) {
             throw new IOException("Unable to fetch the local header");
         }
         close(is);


### PR DESCRIPTION
This will allow the input stream to not read the whole header in one read.