### PR TITLE
Use compressed size from entry if local is zero.

### DIFF
--- a/Pinch/src/guru/benson/pinch/Pinch.java
+++ b/Pinch/src/guru/benson/pinch/Pinch.java
@@ -508,9 +508,14 @@ public class Pinch {
             throw new IOException("Local file header signature mismatch");
         }
 
-        final int localCompressedSize = buffer.getInt(ZipConstants.LOCSIZ);
+        int localCompressedSize = buffer.getInt(ZipConstants.LOCSIZ);
         final short localFileNameLength = buffer.getShort(ZipConstants.LOCNAM);
         final short localExtraLength = buffer.getShort(ZipConstants.LOCEXT);
+
+        // Mac OSX sets the local size to zero when creating the zip in Finder.
+        if (localCompressedSize == 0) {
+            localCompressedSize = (int) entry.getCompressedSize();
+        }
 
         // Define the local file range
         start = entry.getOffset() + ZipConstants.LOCHDR + localFileNameLength + localExtraLength;

--- a/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
+++ b/Pinch/tests/src/guru/benson/pinch/test/PinchTest.java
@@ -47,4 +47,13 @@ public class PinchTest extends InstrumentationTestCase {
             pinch.downloadFile(entry, DOWNLOAD_DIR + File.separator + "testFetchZipWithInvalidCentralData");
         }
     }
+
+    public void testFetchZipWithZeroCompressedSizeLocalHeaders() throws Throwable {
+        URL url = new URL("http://niiranen.net/assets/local-header-compressed-size-0.zip");
+        Pinch pinch = new Pinch(url);
+        List<ExtendedZipEntry> contents = pinch.parseCentralDirectory();
+        for (ExtendedZipEntry entry : contents) {
+            pinch.downloadFile(entry, DOWNLOAD_DIR + File.separator + "testFetchZipWithZeroCompressedSizeLocalHeaders");
+        }
+    }
 }


### PR DESCRIPTION
When creating zip files in OSX using Finder the local header
compressed size will be zero. So if a local header says that the
compressed size is zero we can use the size from the central directory
instead.